### PR TITLE
Save CPU by only processing sounds when they are playing

### DIFF
--- a/HachiKit/DrumWrapper.cpp
+++ b/HachiKit/DrumWrapper.cpp
@@ -1,0 +1,17 @@
+#include "DrumWrapper.h"
+
+using namespace daisy;
+using namespace daisysp;
+
+float DrumWrapper::Process() {
+    if (!IsActive() && cycleCount > CYCLECOUNT_THRESHOLD) return 0.0f;
+
+    cycleCount++;
+    return drum->Process();
+}
+
+void DrumWrapper::Trigger(float velocity) {
+    cycleCount = 0;
+    drum->Trigger(velocity);
+}
+

--- a/HachiKit/DrumWrapper.cpp
+++ b/HachiKit/DrumWrapper.cpp
@@ -4,44 +4,22 @@ using namespace daisy;
 using namespace daisysp;
 
 float DrumWrapper::Process() {
-    // If we're at a sample that we've previously filled, return the sample instead of processing.
-    if (bufferEnabled && bufferIndex < bufferFilledIndex) {
-        if (bufferIndex == BUFFER_SIZE-1) {
-            bufferDone = true;
-        }
-        return buffer[bufferIndex++];
-    }
-
-    // If we've reached the end of the buffer, play no more sound.
-    if (bufferEnabled && bufferDone) {
-        return 0;
-    }
-
     // If the drum is inactive (i.e. done) and we're beyond the first few samples, don't process.
     if (!IsActive() && cycleCount > CYCLECOUNT_THRESHOLD) return 0.0f;
 
     cycleCount++;
-
-    // Otherwise, process.
-    float sig = drum->Process();
-
-    // If we haven't filled this part of the buffer yet, fill it.
-    if (bufferEnabled && bufferIndex >= bufferFilledIndex && bufferFilledIndex < BUFFER_SIZE) {
-        buffer[bufferFilledIndex] = sig;
-        if (bufferFilledIndex > BUFFER_SIZE - BUFFER_FADEOUT) {
-            buffer[bufferFilledIndex] *= (BUFFER_SIZE - bufferFilledIndex - 0.0f) / (BUFFER_FADEOUT + 0.0f);
-        }
-        bufferFilledIndex++;
-    }
-    
-    bufferIndex++;
-    return sig;
+    return drum->Process();
 }
 
 void DrumWrapper::Trigger(float velocity) {
     cycleCount = 0;
-    bufferIndex = 0;
-    bufferDone = false;
     drum->Trigger(velocity);
 }
 
+float DrumWrapper::UpdateParam(uint8_t param, float value) { 
+    return drum->UpdateParam(param, value);
+}
+
+void DrumWrapper::SetParam(uint8_t param, float value) { 
+    drum->SetParam(param, value);
+}

--- a/HachiKit/DrumWrapper.cpp
+++ b/HachiKit/DrumWrapper.cpp
@@ -4,14 +4,44 @@ using namespace daisy;
 using namespace daisysp;
 
 float DrumWrapper::Process() {
+    // If we're at a sample that we've previously filled, return the sample instead of processing.
+    if (bufferEnabled && bufferIndex < bufferFilledIndex) {
+        if (bufferIndex == BUFFER_SIZE-1) {
+            bufferDone = true;
+        }
+        return buffer[bufferIndex++];
+    }
+
+    // If we've reached the end of the buffer, play no more sound.
+    if (bufferEnabled && bufferDone) {
+        return 0;
+    }
+
+    // If the drum is inactive (i.e. done) and we're beyond the first few samples, don't process.
     if (!IsActive() && cycleCount > CYCLECOUNT_THRESHOLD) return 0.0f;
 
     cycleCount++;
-    return drum->Process();
+
+    // Otherwise, process.
+    float sig = drum->Process();
+
+    // If we haven't filled this part of the buffer yet, fill it.
+    if (bufferEnabled && bufferIndex >= bufferFilledIndex && bufferFilledIndex < BUFFER_SIZE) {
+        buffer[bufferFilledIndex] = sig;
+        if (bufferFilledIndex > BUFFER_SIZE - BUFFER_FADEOUT) {
+            buffer[bufferFilledIndex] *= (BUFFER_SIZE - bufferFilledIndex - 0.0f) / (BUFFER_FADEOUT + 0.0f);
+        }
+        bufferFilledIndex++;
+    }
+    
+    bufferIndex++;
+    return sig;
 }
 
 void DrumWrapper::Trigger(float velocity) {
     cycleCount = 0;
+    bufferIndex = 0;
+    bufferDone = false;
     drum->Trigger(velocity);
 }
 

--- a/HachiKit/DrumWrapper.h
+++ b/HachiKit/DrumWrapper.h
@@ -6,13 +6,12 @@
 #include <string>
 #include "IDrum.h"
 #include "Utility.h"
+#include "ParamSet.h"
 
 using namespace daisy;
 using namespace daisysp;
 
 #define CYCLECOUNT_THRESHOLD 1000
-#define BUFFER_SIZE 6000
-#define BUFFER_FADEOUT 100
 
 class DrumWrapper: public IDrum {
 
@@ -27,25 +26,17 @@ class DrumWrapper: public IDrum {
 
         float GetParam(uint8_t param) { return drum->GetParam(param); }
         std::string GetParamString(uint8_t param) { return drum->GetParamString(param); }
-        float UpdateParam(uint8_t param, float value) { return drum->UpdateParam(param, value); }
-        void SetParam(uint8_t param, float value) { drum->SetParam(param, value); }
+        float UpdateParam(uint8_t param, float value);
+        void SetParam(uint8_t param, float value);
         void ResetParams() { drum->ResetParams(); }
 
         std::string Name() { return drum->Name(); }
         std::string Slot() { return drum->Slot(); }
         std::string GetParamName(uint8_t param) { return drum->GetParamName(param); }
 
-        void setBufferEnabled(bool bufferEnabled) { this->bufferEnabled = bufferEnabled; }
-
     private:
         IDrum *drum;
         u32 cycleCount = 0;
-
-        float buffer[BUFFER_SIZE];
-        u16 bufferIndex = 0;
-        u16 bufferFilledIndex = 0;
-        bool bufferDone = false;
-        bool bufferEnabled = true;
 
 };
 

--- a/HachiKit/DrumWrapper.h
+++ b/HachiKit/DrumWrapper.h
@@ -11,6 +11,8 @@ using namespace daisy;
 using namespace daisysp;
 
 #define CYCLECOUNT_THRESHOLD 1000
+#define BUFFER_SIZE 6000
+#define BUFFER_FADEOUT 100
 
 class DrumWrapper: public IDrum {
 
@@ -33,9 +35,17 @@ class DrumWrapper: public IDrum {
         std::string Slot() { return drum->Slot(); }
         std::string GetParamName(uint8_t param) { return drum->GetParamName(param); }
 
+        void setBufferEnabled(bool bufferEnabled) { this->bufferEnabled = bufferEnabled; }
+
     private:
         IDrum *drum;
         u32 cycleCount = 0;
+
+        float buffer[BUFFER_SIZE];
+        u16 bufferIndex = 0;
+        u16 bufferFilledIndex = 0;
+        bool bufferDone = false;
+        bool bufferEnabled = true;
 
 };
 

--- a/HachiKit/DrumWrapper.h
+++ b/HachiKit/DrumWrapper.h
@@ -1,0 +1,44 @@
+#ifndef DRUMWRAPPER_H
+#define DRUMWRAPPER_H
+
+#include "daisy_patch.h"
+#include "daisysp.h"
+#include <string>
+#include "IDrum.h"
+#include "Utility.h"
+
+using namespace daisy;
+using namespace daisysp;
+
+#define CYCLECOUNT_THRESHOLD 1000
+
+class DrumWrapper: public IDrum {
+
+    public:
+        u8 ParamCount() { return drum->ParamCount(); }
+
+        void Init(std::string slot, float sample_rate) { drum->Init(slot, sample_rate); }
+        void Init(IDrum *drum) { this->drum = drum; }
+        float Process();
+        void Trigger(float velocity);
+        bool IsActive() { return drum->IsActive(); }
+
+        float GetParam(uint8_t param) { return drum->GetParam(param); }
+        std::string GetParamString(uint8_t param) { return drum->GetParamString(param); }
+        float UpdateParam(uint8_t param, float value) { return drum->UpdateParam(param, value); }
+        void SetParam(uint8_t param, float value) { drum->SetParam(param, value); }
+        void ResetParams() { drum->ResetParams(); }
+
+        std::string Name() { return drum->Name(); }
+        std::string Slot() { return drum->Slot(); }
+        std::string GetParamName(uint8_t param) { return drum->GetParamName(param); }
+
+    private:
+        IDrum *drum;
+        u32 cycleCount = 0;
+
+};
+
+
+
+#endif

--- a/HachiKit/HachiKit.cpp
+++ b/HachiKit/HachiKit.cpp
@@ -30,30 +30,6 @@ CpuLoadMeter meter;
 
 Mixer mixer;
 
-// IDrum *drums[16];
-// u8 drumCount = 0;
-
-// Bd8 bd;
-// DrumWrapper bdWrapper;
-// SdNoise rs;
-// Sd8 sd;
-// Clap cp;
-// DigiClap sd2;
-// Tom lt, mt, ht;
-// // MultiTom lt, mt, ht;
-// Ch ch;
-// Oh oh;
-// SdNoise ma;
-// Cy cy;
-// Cow8 cb;
-// FmDrum fm1, fm2;
-// Clave8 cl;
-
-// // Shared sound sources
-// HhSource68 source68;
-// ClickSource clickSource;
-// // MultiTomSource multiTomSource;
-
 u8 currentMenu = 0; 
 u8 currentMenuIndex = 0;
 uint8_t currentDrum = 0;
@@ -270,12 +246,13 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         cycle = (cycle + 1) % clockRange;
         if (cycle < clockThreshold) {
             // Process shared sound sources
-            if (ch.IsActive() || oh.IsActive() || cy.IsActive()) {
-                // is always active, so we skip it when the sounds that use it aren't active
-                source68.Process();
+            for (u8 i = 0; i < sourceCount; i++) {
+                sources[i]->Process();
             }
-            clickSource.Process();  // has its own env, so isn't always active
-            // multiTomSource.Process();
+            // if (ch.IsActive() || oh.IsActive() || cy.IsActive()) {
+            //     // is always active, so we skip it when the sounds that use it aren't active
+            //     source68.Process();
+            // }
 
             if (CPU_SINGLE) {
                 mixer.UpdateSignal(currentDrum, drums[currentDrum]->Process());
@@ -357,55 +334,9 @@ int main(void)
     // Init the hardware
     float samplerate;
     hw.Init(true);     // "true" boosts processor speed from 400mhz to 480mhz
-    hw.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_32KHZ);  // 8,16,32,48; higher rate requires more CPU
+    hw.SetAudioSampleRate(audioSampleRate);  // 8,16,32,48; higher rate requires more CPU
     samplerate = hw.AudioSampleRate();
     meter.Init(samplerate, 128, 1.0f);
-
-    // // Shared sound sources
-    // source68.Init("", samplerate, HhSource68::MORPH_808_VALUE);
-    // clickSource.Init("", samplerate, 1500, 191, 116);
-    // // multiTomSource.Init("", samplerate, 500, &clickSource);
-
-    // bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
-    // bdWrapper.Init(&bd);
-    // rs.Init("RS", samplerate);
-    // sd.Init("SD", samplerate);
-    // cp.Init("CP", samplerate, 0.012, 0.8);
-    // sd2.Init("S2", samplerate, 0.012, 0.8, 3000);
-
-    // lt.Init("LT", samplerate, 80, &clickSource);
-    // mt.Init("MT", samplerate, 91, &clickSource);
-    // ht.Init("HT", samplerate, 106, &clickSource);
-    // // lt.Init("LT", samplerate, 80, 0.8, &multiTomSource, 0);
-    // // mt.Init("MT", samplerate, 91, 0.8, &multiTomSource, 1);
-    // // ht.Init("HT", samplerate, 106, 0.8, &multiTomSource, 2);
-
-
-    // ch.Init("CH", samplerate, 0.001, 0.5, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
-    // oh.Init("OH", samplerate, 0.001, 0.13, 0.001, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
-    // ma.Init("MA", samplerate);
-    // cy.Init("CY", samplerate, 0.001, 3.5, &source68, 1700, 2400);
-    // cb.Init("CB", samplerate, 0.005, 0.5, &source68, 1700, 2400);
-    // fm1.Init("LC", samplerate, 98, 3.3, 2.2, 0.001, 0.101, -50);
-    // fm2.Init("HC", samplerate, 131, 3.3, 2.2, 0.001, 0.101, -50);
-    // cl.Init("CL", samplerate, 2000, 0.375);
-
-    // drums[0] = &bdWrapper;
-    // drums[1] = &rs;
-    // drums[2] = &sd;
-    // drums[3] = &cp;
-    // drums[4] = &sd2;
-    // drums[5] = &lt;
-    // drums[6] = &ch;
-    // drums[7] = &mt;
-    // drums[8] = &ma;
-    // drums[9] = &ht;
-    // drums[10] = &oh;
-    // drums[11] = &fm1;
-    // drums[12] = &fm2;
-    // drums[13] = &cy;
-    // drums[14] = &cl;
-    // drums[15] = &cb;
 
     // Set up the kit and mixer
     InitKit(samplerate);
@@ -443,16 +374,6 @@ int main(void)
     for (u8 i = 0; i < KNOB_COUNT; i++) {
         lastKnobValue[i] = 0.0f;
     }
-
-
-    //display
-    // hw.display.Fill(false);
-    // screen.OledMessage("Hachikit 0.1", 5);
-    // Utility::DrawDrums(&hw.display, 5);
-    // screen.DrawMenu(currentMenuIndex);
-    // DisplayParamMenu();
-    // hw.display.Update();
-
 
     DrawScreen(true);
 

--- a/HachiKit/HachiKit.cpp
+++ b/HachiKit/HachiKit.cpp
@@ -12,22 +12,7 @@
 #include "IDrum.h"
 #include "Kits.h"
 #include "Screen.h"
-#include "sounds/Bd8.h"
-#include "sounds/Ch.h"
-#include "sounds/Clap.h"
-#include "sounds/Clave8.h"
-#include "sounds/ClickSource.h"
-#include "sounds/Cow8.h"
-#include "sounds/Cy.h"
-#include "sounds/DigiClap.h"
-#include "sounds/FmDrum.h"
-#include "sounds/HhSource68.h"
-#include "sounds/MultiTomSource.h"
-#include "sounds/MultiTom.h"
-#include "sounds/Oh.h"
-#include "sounds/Sd8.h"
-#include "sounds/SdNoise.h"
-#include "sounds/Tom.h"
+
 
 using namespace daisy;
 using namespace daisysp;
@@ -214,8 +199,10 @@ void ProcessEncoder() {
 
     if (screenOn) {
         usageCounter = 0;
-        screen.SetScreenOn(true);
-        hw.display.Fill(false);
+        if (!screen.IsScreenOn()) {
+            screen.SetScreenOn(true);
+            hw.display.Fill(false);
+        }
     }
     if (redraw) {
         DrawScreen(true);
@@ -231,7 +218,7 @@ void ProcessKnobs() {
         float sig = hw.controls[knob].Value();
         if (currentMenu ==  0) {
             u8 param = currentKnobRow * KNOB_COUNT + knob;
-            drums[currentDrum]->UpdateParam(param, sig);
+            drums[currentDrum]->UpdateParam(param, sig);   // TODO bool changed = 
             if (std::abs(sig - lastKnobValue[knob]) > 0.1f) {    // TODO: use delta value from Param?
                 usageCounter = 0;
                 lastKnobValue[knob] = sig;
@@ -370,7 +357,7 @@ int main(void)
     // Init the hardware
     float samplerate;
     hw.Init(true);     // "true" boosts processor speed from 400mhz to 480mhz
-    hw.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_48KHZ);  // 8,16,32,48; higher rate requires more CPU
+    hw.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_32KHZ);  // 8,16,32,48; higher rate requires more CPU
     samplerate = hw.AudioSampleRate();
     meter.Init(samplerate, 128, 1.0f);
 

--- a/HachiKit/HachiKit.cpp
+++ b/HachiKit/HachiKit.cpp
@@ -170,6 +170,7 @@ void ProcessEncoder() {
 
     int inc = hw.encoder.Increment();
     u8 newMenuIndex = Utility::LimitInt(currentMenuIndex + inc, 0, Screen::MENU_SIZE-1);
+    // u8 newMenuIndex = (currentMenuIndex + inc) % Screen::MENU_SIZE;
     if (newMenuIndex != currentMenuIndex) {
         if (newMenuIndex < drumCount) {
             currentMenu = MENU_SOUNDS;
@@ -185,8 +186,6 @@ void ProcessEncoder() {
         }
 
         currentMenuIndex = newMenuIndex;
-        usageCounter = 0;
-        screen.SetScreenOn(true);
         redraw = true;
         hw.display.Fill(false);
     }
@@ -275,8 +274,11 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         cycle = (cycle + 1) % clockRange;
         if (cycle < clockThreshold) {
             // Process shared sound sources
-            source68.Process();
-            clickSource.Process();
+            if (ch.IsActive() || oh.IsActive() || cy.IsActive()) {
+                // is always active, so we skip it when the sounds that use it aren't active
+                source68.Process();
+            }
+            clickSource.Process();  // has its own env, so isn't always active
             // multiTomSource.Process();
 
             if (CPU_SINGLE) {
@@ -472,7 +474,7 @@ int main(void)
         screen.ShowCpu(avgCpu);
 
         usageCounter++;
-        if (usageCounter > 1000) {    // 10000=about 90 seconds
+        if (usageCounter > 10000) {    // 10000=about 90 seconds
             if (screen.IsScreenOn()) {
                 screen.SetScreenOn(false);
             }

--- a/HachiKit/HachiKit.cpp
+++ b/HachiKit/HachiKit.cpp
@@ -469,6 +469,7 @@ int main(void)
 
         float avgCpu = meter.GetAvgCpuLoad();
         screen.OledMessage("cpu:" + std::to_string((int)(avgCpu * 100)) + "%", 4, 10);
+        screen.ShowCpu(avgCpu);
 
         usageCounter++;
         if (usageCounter > 1000) {    // 10000=about 90 seconds

--- a/HachiKit/HachiKit.cpp
+++ b/HachiKit/HachiKit.cpp
@@ -171,8 +171,12 @@ void DrawScreen(bool clearFirst) {
 void ProcessEncoder() {
 
     bool redraw = false;
+    bool screenOn = false;
 
     int inc = hw.encoder.Increment();
+    if (inc != 0) {
+        screenOn = true;
+    }
     u8 newMenuIndex = Utility::LimitInt(currentMenuIndex + inc, 0, Screen::MENU_SIZE-1);
     // u8 newMenuIndex = (currentMenuIndex + inc) % Screen::MENU_SIZE;
     if (newMenuIndex != currentMenuIndex) {
@@ -199,21 +203,22 @@ void ProcessEncoder() {
             currentKnobRow = (currentKnobRow + 1) % MENU_ROWS;
             redraw = true;
             drums[currentDrum]->ResetParams();
-            usageCounter = 0;
-            screen.SetScreenOn(true);
-            hw.display.Fill(false);
+            screenOn = true;
         } else if (currentMenu == MENU_MIXER) {
             currentKnobRow = (currentKnobRow + 1) % MENU_ROWS;
             redraw = true;
             // reset params for mixer row?
-            usageCounter = 0;
-            screen.SetScreenOn(true);
-            hw.display.Fill(false);
+            screenOn = true;
         }
     }
 
+    if (screenOn) {
+        usageCounter = 0;
+        screen.SetScreenOn(true);
+        hw.display.Fill(false);
+    }
     if (redraw) {
-        DrawScreen(false);
+        DrawScreen(true);
         hw.display.Update();        
     }
 }
@@ -365,7 +370,7 @@ int main(void)
     // Init the hardware
     float samplerate;
     hw.Init(true);     // "true" boosts processor speed from 400mhz to 480mhz
-    hw.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_32KHZ);  // 8,16,32,48; higher rate requires more CPU
+    hw.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_48KHZ);  // 8,16,32,48; higher rate requires more CPU
     samplerate = hw.AudioSampleRate();
     meter.Init(samplerate, 128, 1.0f);
 
@@ -484,7 +489,7 @@ int main(void)
         screen.ShowCpu(avgCpu);
 
         usageCounter++;
-        if (usageCounter > 10000) {    // 10000=about 90 seconds
+        if (usageCounter > 3000) {    // 10000=about 90 seconds
             if (screen.IsScreenOn()) {
                 screen.SetScreenOn(false);
             }

--- a/HachiKit/HachiKit.cpp
+++ b/HachiKit/HachiKit.cpp
@@ -8,8 +8,10 @@
 #include "Utility.h"
 #include "audio/Mixer.h"
 #include "audio/Processing.h"
-#include "Screen.h"
+#include "DrumWrapper.h"
 #include "IDrum.h"
+#include "Kits.h"
+#include "Screen.h"
 #include "sounds/Bd8.h"
 #include "sounds/Ch.h"
 #include "sounds/Clap.h"
@@ -43,27 +45,29 @@ CpuLoadMeter meter;
 
 Mixer mixer;
 
-IDrum *drums[16];
-uint8_t drumCount = 1;
-Bd8 bd;
-SdNoise rs;
-Sd8 sd;
-Clap cp;
-DigiClap sd2;
-Tom lt, mt, ht;
-// MultiTom lt, mt, ht;
-Ch ch;
-Oh oh;
-SdNoise ma;
-Cy cy;
-Cow8 cb;
-FmDrum fm1, fm2;
-Clave8 cl;
+// IDrum *drums[16];
+// u8 drumCount = 0;
 
-// Shared sound sources
-HhSource68 source68;
-ClickSource clickSource;
-// MultiTomSource multiTomSource;
+// Bd8 bd;
+// DrumWrapper bdWrapper;
+// SdNoise rs;
+// Sd8 sd;
+// Clap cp;
+// DigiClap sd2;
+// Tom lt, mt, ht;
+// // MultiTom lt, mt, ht;
+// Ch ch;
+// Oh oh;
+// SdNoise ma;
+// Cy cy;
+// Cow8 cb;
+// FmDrum fm1, fm2;
+// Clave8 cl;
+
+// // Shared sound sources
+// HhSource68 source68;
+// ClickSource clickSource;
+// // MultiTomSource multiTomSource;
 
 u8 currentMenu = 0; 
 u8 currentMenuIndex = 0;
@@ -358,61 +362,62 @@ void HandleMidiMessage(MidiEvent m)
 // Main -- Init, and Midi Handling
 int main(void)
 {
-    // Init
+    // Init the hardware
     float samplerate;
     hw.Init(true);     // "true" boosts processor speed from 400mhz to 480mhz
     hw.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_32KHZ);  // 8,16,32,48; higher rate requires more CPU
     samplerate = hw.AudioSampleRate();
-
     meter.Init(samplerate, 128, 1.0f);
 
+    // // Shared sound sources
+    // source68.Init("", samplerate, HhSource68::MORPH_808_VALUE);
+    // clickSource.Init("", samplerate, 1500, 191, 116);
+    // // multiTomSource.Init("", samplerate, 500, &clickSource);
+
+    // bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
+    // bdWrapper.Init(&bd);
+    // rs.Init("RS", samplerate);
+    // sd.Init("SD", samplerate);
+    // cp.Init("CP", samplerate, 0.012, 0.8);
+    // sd2.Init("S2", samplerate, 0.012, 0.8, 3000);
+
+    // lt.Init("LT", samplerate, 80, &clickSource);
+    // mt.Init("MT", samplerate, 91, &clickSource);
+    // ht.Init("HT", samplerate, 106, &clickSource);
+    // // lt.Init("LT", samplerate, 80, 0.8, &multiTomSource, 0);
+    // // mt.Init("MT", samplerate, 91, 0.8, &multiTomSource, 1);
+    // // ht.Init("HT", samplerate, 106, 0.8, &multiTomSource, 2);
+
+
+    // ch.Init("CH", samplerate, 0.001, 0.5, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
+    // oh.Init("OH", samplerate, 0.001, 0.13, 0.001, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
+    // ma.Init("MA", samplerate);
+    // cy.Init("CY", samplerate, 0.001, 3.5, &source68, 1700, 2400);
+    // cb.Init("CB", samplerate, 0.005, 0.5, &source68, 1700, 2400);
+    // fm1.Init("LC", samplerate, 98, 3.3, 2.2, 0.001, 0.101, -50);
+    // fm2.Init("HC", samplerate, 131, 3.3, 2.2, 0.001, 0.101, -50);
+    // cl.Init("CL", samplerate, 2000, 0.375);
+
+    // drums[0] = &bdWrapper;
+    // drums[1] = &rs;
+    // drums[2] = &sd;
+    // drums[3] = &cp;
+    // drums[4] = &sd2;
+    // drums[5] = &lt;
+    // drums[6] = &ch;
+    // drums[7] = &mt;
+    // drums[8] = &ma;
+    // drums[9] = &ht;
+    // drums[10] = &oh;
+    // drums[11] = &fm1;
+    // drums[12] = &fm2;
+    // drums[13] = &cy;
+    // drums[14] = &cl;
+    // drums[15] = &cb;
+
+    // Set up the kit and mixer
+    InitKit(samplerate);
     mixer.Reset();
-
-    // Shared sound sources
-    source68.Init("", samplerate, HhSource68::MORPH_808_VALUE);
-    clickSource.Init("", samplerate, 1500, 191, 116);
-    // multiTomSource.Init("", samplerate, 500, &clickSource);
-
-    bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
-    rs.Init("RS", samplerate);
-    sd.Init("SD", samplerate);
-    cp.Init("CP", samplerate, 0.012, 0.8);
-    sd2.Init("S2", samplerate, 0.012, 0.8, 3000);
-
-    lt.Init("LT", samplerate, 80, &clickSource);
-    mt.Init("MT", samplerate, 91, &clickSource);
-    ht.Init("HT", samplerate, 106, &clickSource);
-    // lt.Init("LT", samplerate, 80, 0.8, &multiTomSource, 0);
-    // mt.Init("MT", samplerate, 91, 0.8, &multiTomSource, 1);
-    // ht.Init("HT", samplerate, 106, 0.8, &multiTomSource, 2);
-
-
-    ch.Init("CH", samplerate, 0.001, 0.5, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
-    oh.Init("OH", samplerate, 0.001, 0.13, 0.001, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
-    ma.Init("MA", samplerate);
-    cy.Init("CY", samplerate, 0.001, 3.5, &source68, 1700, 2400);
-    cb.Init("CB", samplerate, 0.005, 0.5, &source68, 1700, 2400);
-    fm1.Init("LC", samplerate, 98, 3.3, 2.2, 0.001, 0.101, -50);
-    fm2.Init("HC", samplerate, 131, 3.3, 2.2, 0.001, 0.101, -50);
-    cl.Init("CL", samplerate, 2000, 0.375);
-
-    drums[0] = &bd;
-    drums[1] = &rs;
-    drums[2] = &sd;
-    drums[3] = &cp;
-    drums[4] = &sd2;
-    drums[5] = &lt;
-    drums[6] = &ch;
-    drums[7] = &mt;
-    drums[8] = &ma;
-    drums[9] = &ht;
-    drums[10] = &oh;
-    drums[11] = &fm1;
-    drums[12] = &fm2;
-    drums[13] = &cy;
-    drums[14] = &cl;
-    drums[15] = &cb;
-    drumCount = 16;
     currentDrum = 0;
     currentMenuIndex = 0;
 
@@ -428,18 +433,6 @@ int main(void)
     mixer.SetChannelParam(14, Channel::PARAM_SEND2, 1);
     mixer.SetChannelParam(15, Channel::PARAM_SEND2, 1);
 
-    for (u8 i = 0; i < KNOB_COUNT; i++) {
-        lastKnobValue[i] = 0.0f;
-    }
-
-    //display
-    hw.display.Fill(false);
-    // screen.OledMessage("Hachikit 0.1", 5);
-    // Utility::DrawDrums(&hw.display, 5);
-    screen.DrawMenu(currentMenuIndex);
-    DisplayParamMenu();
-    hw.display.Update();
-
     // fill the menu
     for (u8 drum = 0; drum < drumCount; drum++) {
         screen.menuItems[drum] = drums[drum]->Slot();
@@ -453,6 +446,23 @@ int main(void)
         screen.menuItems[drumCount+2] = "C";
         screen.menuItems[drumCount+3] = "D";
     }
+
+    // initialize the knob tracking
+    for (u8 i = 0; i < KNOB_COUNT; i++) {
+        lastKnobValue[i] = 0.0f;
+    }
+
+
+    //display
+    // hw.display.Fill(false);
+    // screen.OledMessage("Hachikit 0.1", 5);
+    // Utility::DrawDrums(&hw.display, 5);
+    // screen.DrawMenu(currentMenuIndex);
+    // DisplayParamMenu();
+    // hw.display.Update();
+
+
+    DrawScreen(true);
 
     // Start stuff.
     hw.SetAudioBlockSize(128);

--- a/HachiKit/IDrum.h
+++ b/HachiKit/IDrum.h
@@ -35,6 +35,12 @@ class IDrum {
         */
         virtual void Trigger(float velocity) = 0;
 
+        /**
+         * IsActive
+         * Whether the drum is currently making sound or has finished.
+        */
+        virtual bool IsActive() = 0;
+
         /** Get the current value of a parameter.
          * \param param index of the desired parameter (must be < PARAM_COUNT).
         */

--- a/HachiKit/Kits.h
+++ b/HachiKit/Kits.h
@@ -5,9 +5,11 @@
  * Uses compiler directives to avoid extra overhead.
  * Must include these declarations:
  *   IDrum *drums[N];
+ *   IDrum *sources[M];
  *   u8 drumCount = N;
+ *   u8 sourceCount = M;
  *   void InitKit(float samplerate) {}
- * 
+ *   SaiHandle::Config::SampleRate audioSampleRate = SaiHandle::Config::<rate>;
 */
 #ifndef KITS_H
 #define KITS_H
@@ -16,22 +18,7 @@
 #include "daisysp.h"
 #include "IDrum.h"
 #include "Utility.h"
-#include "sounds/Bd8.h"
-#include "sounds/Ch.h"
-#include "sounds/Clap.h"
-#include "sounds/Clave8.h"
-#include "sounds/ClickSource.h"
-#include "sounds/Cow8.h"
-#include "sounds/Cy.h"
-#include "sounds/DigiClap.h"
-#include "sounds/FmDrum.h"
-#include "sounds/HhSource68.h"
-#include "sounds/MultiTomSource.h"
-#include "sounds/MultiTom.h"
-#include "sounds/Oh.h"
-#include "sounds/Sd8.h"
-#include "sounds/SdNoise.h"
-#include "sounds/Tom.h"
+
 
 // #define SELECTED_KIT 0
 
@@ -39,7 +26,7 @@
 // #include "kits/kit-abcd.h"
 // #endif
 
-#include "kits/kit-abcd.h"
+#include "kits/kit-abcd-32k.h"
 // #include "kits/testing.h"
 
 #endif

--- a/HachiKit/Kits.h
+++ b/HachiKit/Kits.h
@@ -39,6 +39,7 @@
 // #include "kits/kit-abcd.h"
 // #endif
 
-#include "kits/testing.h"
+#include "kits/kit-abcd.h"
+// #include "kits/testing.h"
 
 #endif

--- a/HachiKit/Kits.h
+++ b/HachiKit/Kits.h
@@ -1,0 +1,124 @@
+/**
+ * Kits
+ * 
+ * Sets up all the drum sounds and the kit.
+ * Uses compiler directives to avoid extra overhead.
+ * Must include these declarations:
+ *   IDrum *drums[N];
+ *   u8 drumCount = N;
+ *   void InitKit(float samplerate) {}
+ * 
+*/
+#ifndef KITS_H
+#define KITS_H
+
+#include "daisy_patch.h"
+#include "daisysp.h"
+#include "IDrum.h"
+#include "Utility.h"
+#include "sounds/Bd8.h"
+#include "sounds/Ch.h"
+#include "sounds/Clap.h"
+#include "sounds/Clave8.h"
+#include "sounds/ClickSource.h"
+#include "sounds/Cow8.h"
+#include "sounds/Cy.h"
+#include "sounds/DigiClap.h"
+#include "sounds/FmDrum.h"
+#include "sounds/HhSource68.h"
+#include "sounds/MultiTomSource.h"
+#include "sounds/MultiTom.h"
+#include "sounds/Oh.h"
+#include "sounds/Sd8.h"
+#include "sounds/SdNoise.h"
+#include "sounds/Tom.h"
+
+#define SELECTED_KIT 0
+
+#if SELECTED_KIT == 0
+
+IDrum *drums[16];
+u8 drumCount = 16;
+DrumWrapper drumWrappers[16];
+
+Bd8 bd;
+DrumWrapper bdWrapper;
+SdNoise rs;
+Sd8 sd;
+Clap cp;
+DigiClap sd2;
+Tom lt, mt, ht;
+// MultiTom lt, mt, ht;
+Ch ch;
+Oh oh;
+SdNoise ma;
+Cy cy;
+Cow8 cb;
+FmDrum fm1, fm2;
+Clave8 cl;
+
+// Shared sound sources
+HhSource68 source68;
+ClickSource clickSource;
+// MultiTomSource multiTomSource;
+
+void InitKit(float samplerate) {
+
+    // Init any sound sources
+    source68.Init("", samplerate, HhSource68::MORPH_808_VALUE);
+    clickSource.Init("", samplerate, 1500, 191, 116);
+    // multiTomSource.Init("", samplerate, 500, &clickSource);
+
+    // Init all drum sounds
+    bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
+    bdWrapper.Init(&bd);
+    rs.Init("RS", samplerate);
+    sd.Init("SD", samplerate);
+    cp.Init("CP", samplerate, 0.012, 0.8);
+    sd2.Init("S2", samplerate, 0.012, 0.8, 3000);
+
+    lt.Init("LT", samplerate, 80, &clickSource);
+    mt.Init("MT", samplerate, 91, &clickSource);
+    ht.Init("HT", samplerate, 106, &clickSource);
+    // lt.Init("LT", samplerate, 80, 0.8, &multiTomSource, 0);
+    // mt.Init("MT", samplerate, 91, 0.8, &multiTomSource, 1);
+    // ht.Init("HT", samplerate, 106, 0.8, &multiTomSource, 2);
+
+
+    ch.Init("CH", samplerate, 0.001, 0.5, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
+    oh.Init("OH", samplerate, 0.001, 0.13, 0.001, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
+    ma.Init("MA", samplerate);
+    cy.Init("CY", samplerate, 0.001, 3.5, &source68, 1700, 2400);
+    cb.Init("CB", samplerate, 0.005, 0.5, &source68, 1700, 2400);
+    fm1.Init("LC", samplerate, 98, 3.3, 2.2, 0.001, 0.101, -50);
+    fm2.Init("HC", samplerate, 131, 3.3, 2.2, 0.001, 0.101, -50);
+    cl.Init("CL", samplerate, 2000, 0.375);
+
+    // Assign sounds to kit
+    drums[0] = &bdWrapper;
+    drums[1] = &rs;
+    drums[2] = &sd;
+    drums[3] = &cp;
+    drums[4] = &sd2;
+    drums[5] = &lt;
+    drums[6] = &ch;
+    drums[7] = &mt;
+    drums[8] = &ma;
+    drums[9] = &ht;
+    drums[10] = &oh;
+    drums[11] = &fm1;
+    drums[12] = &fm2;
+    drums[13] = &cy;
+    drums[14] = &cl;
+    drums[15] = &cb;
+
+    for (u8 i = 0; i < drumCount; i++) {
+        drumWrappers[i].Init(drums[i]);
+        drums[i] = &drumWrappers[i];
+    }
+}
+
+#endif // kit==0
+
+
+#endif

--- a/HachiKit/Kits.h
+++ b/HachiKit/Kits.h
@@ -75,7 +75,7 @@ void InitKit(float samplerate) {
     rs.Init("RS", samplerate);
     sd.Init("SD", samplerate);
     cp.Init("CP", samplerate, 0.012, 0.8);
-    sd2.Init("S2", samplerate, 0.012, 0.8, 3000);
+    sd2.Init("S2", samplerate, 0.012, 0.8, 3000, 0);
 
     lt.Init("LT", samplerate, 80, &clickSource);
     mt.Init("MT", samplerate, 91, &clickSource);

--- a/HachiKit/Kits.h
+++ b/HachiKit/Kits.h
@@ -71,7 +71,6 @@ void InitKit(float samplerate) {
 
     // Init all drum sounds
     bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
-    bdWrapper.Init(&bd);
     rs.Init("RS", samplerate);
     sd.Init("SD", samplerate);
     cp.Init("CP", samplerate, 0.012, 0.8);
@@ -95,7 +94,7 @@ void InitKit(float samplerate) {
     cl.Init("CL", samplerate, 2000, 0.375);
 
     // Assign sounds to kit
-    drums[0] = &bdWrapper;
+    drums[0] = &bd;
     drums[1] = &rs;
     drums[2] = &sd;
     drums[3] = &cp;
@@ -116,6 +115,11 @@ void InitKit(float samplerate) {
         drumWrappers[i].Init(drums[i]);
         drums[i] = &drumWrappers[i];
     }
+    
+    // buffers don't work well with claps; cymbal is just too long
+    drumWrappers[3].setBufferEnabled(false);
+    drumWrappers[4].setBufferEnabled(false);
+    drumWrappers[13].setBufferEnabled(false);
 }
 
 #endif // kit==0

--- a/HachiKit/Kits.h
+++ b/HachiKit/Kits.h
@@ -33,96 +33,12 @@
 #include "sounds/SdNoise.h"
 #include "sounds/Tom.h"
 
-#define SELECTED_KIT 0
+// #define SELECTED_KIT 0
 
-#if SELECTED_KIT == 0
+// #if SELECTED_KIT == 0
+// #include "kits/kit-abcd.h"
+// #endif
 
-IDrum *drums[16];
-u8 drumCount = 16;
-DrumWrapper drumWrappers[16];
-
-Bd8 bd;
-DrumWrapper bdWrapper;
-SdNoise rs;
-Sd8 sd;
-Clap cp;
-DigiClap sd2;
-Tom lt, mt, ht;
-// MultiTom lt, mt, ht;
-Ch ch;
-Oh oh;
-SdNoise ma;
-Cy cy;
-Cow8 cb;
-FmDrum fm1, fm2;
-Clave8 cl;
-
-// Shared sound sources
-HhSource68 source68;
-ClickSource clickSource;
-// MultiTomSource multiTomSource;
-
-void InitKit(float samplerate) {
-
-    // Init any sound sources
-    source68.Init("", samplerate, HhSource68::MORPH_808_VALUE);
-    clickSource.Init("", samplerate, 1500, 191, 116);
-    // multiTomSource.Init("", samplerate, 500, &clickSource);
-
-    // Init all drum sounds
-    bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
-    rs.Init("RS", samplerate);
-    sd.Init("SD", samplerate);
-    cp.Init("CP", samplerate, 0.012, 0.8);
-    sd2.Init("S2", samplerate, 0.012, 0.8, 3000, 0);
-
-    lt.Init("LT", samplerate, 80, &clickSource);
-    mt.Init("MT", samplerate, 91, &clickSource);
-    ht.Init("HT", samplerate, 106, &clickSource);
-    // lt.Init("LT", samplerate, 80, 0.8, &multiTomSource, 0);
-    // mt.Init("MT", samplerate, 91, 0.8, &multiTomSource, 1);
-    // ht.Init("HT", samplerate, 106, 0.8, &multiTomSource, 2);
-
-
-    ch.Init("CH", samplerate, 0.001, 0.5, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
-    oh.Init("OH", samplerate, 0.001, 0.13, 0.001, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
-    ma.Init("MA", samplerate);
-    cy.Init("CY", samplerate, 0.001, 3.5, &source68, 1700, 2400);
-    cb.Init("CB", samplerate, 0.005, 0.5, &source68, 1700, 2400);
-    fm1.Init("LC", samplerate, 98, 3.3, 2.2, 0.001, 0.101, -50);
-    fm2.Init("HC", samplerate, 131, 3.3, 2.2, 0.001, 0.101, -50);
-    cl.Init("CL", samplerate, 2000, 0.375);
-
-    // Assign sounds to kit
-    drums[0] = &bd;
-    drums[1] = &rs;
-    drums[2] = &sd;
-    drums[3] = &cp;
-    drums[4] = &sd2;
-    drums[5] = &lt;
-    drums[6] = &ch;
-    drums[7] = &mt;
-    drums[8] = &ma;
-    drums[9] = &ht;
-    drums[10] = &oh;
-    drums[11] = &fm1;
-    drums[12] = &fm2;
-    drums[13] = &cy;
-    drums[14] = &cl;
-    drums[15] = &cb;
-
-    for (u8 i = 0; i < drumCount; i++) {
-        drumWrappers[i].Init(drums[i]);
-        drums[i] = &drumWrappers[i];
-    }
-    
-    // buffers don't work well with claps; cymbal is just too long
-    drumWrappers[3].setBufferEnabled(false);
-    drumWrappers[4].setBufferEnabled(false);
-    drumWrappers[13].setBufferEnabled(false);
-}
-
-#endif // kit==0
-
+#include "kits/testing.h"
 
 #endif

--- a/HachiKit/Makefile
+++ b/HachiKit/Makefile
@@ -4,6 +4,7 @@ TARGET = HachiKit
 # Sources
 CPP_SOURCES += HachiKit.cpp \
 ParamSet.cpp \
+DrumWrapper.cpp \
 Screen.cpp \
 audio/AhdEnv.cpp \
 audio/Mixer.cpp \

--- a/HachiKit/Screen.cpp
+++ b/HachiKit/Screen.cpp
@@ -127,3 +127,15 @@ void Screen::OledMessage(std::string message, int row, int column) {
     display->Update();
 }
 
+void Screen::ShowCpu(float usage) {
+    if (!screenOn) { return; }
+
+    u8 menuHeight = FONT.FontWidth + 4;
+    u8 scaled = (int)(usage * WIDTH);
+    u8 qtr = WIDTH / 4;
+    display->DrawRect(0, HEIGHT - menuHeight - 3, WIDTH, HEIGHT - menuHeight - 1, false, true);
+    display->DrawRect(0, HEIGHT - menuHeight - 3, scaled, HEIGHT - menuHeight - 1, true, true);
+    display->DrawLine(qtr, HEIGHT - menuHeight - 4, qtr, HEIGHT - menuHeight -1, true);
+    display->DrawLine(2 * qtr, HEIGHT - menuHeight - 4, 2 * qtr, HEIGHT - menuHeight -1, true);
+    display->DrawLine(3 * qtr, HEIGHT - menuHeight - 4, 3 * qtr, HEIGHT - menuHeight -1, true);
+}

--- a/HachiKit/Screen.h
+++ b/HachiKit/Screen.h
@@ -51,6 +51,8 @@ class Screen {
         void OledMessage(std::string message, int row);
         void OledMessage(std::string message, int row, int column);
 
+        void ShowCpu(float usage);
+
     private:
         OledDisplay<SSD130x4WireSpi128x64Driver> *display;
         bool screenOn = true;

--- a/HachiKit/dfu.sh
+++ b/HachiKit/dfu.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+
+echo $1
+
+if [ "$1" == "" ]; then
+	echo "Usage: dfu.sh <binfile>"
+	exit
+fi
+
+dfu-util -a 0 -s 0x08000000:leave -D $1 -d ,0483:df11

--- a/HachiKit/kits/kit-abcd-32k.h
+++ b/HachiKit/kits/kit-abcd-32k.h
@@ -2,11 +2,33 @@
 #ifndef DRUMKIT_H
 #define DRUMKIT_H
 
+#include "../sounds/Bd8.h"
+#include "../sounds/Ch.h"
+#include "../sounds/Clap.h"
+#include "../sounds/Clave8.h"
+#include "../sounds/ClickSource.h"
+#include "../sounds/Cow8.h"
+#include "../sounds/Cy.h"
+#include "../sounds/DigiClap.h"
+#include "../sounds/FmDrum.h"
+#include "../sounds/HhSource68.h"
+#include "../sounds/MultiTomSource.h"
+#include "../sounds/MultiTom.h"
+#include "../sounds/Oh.h"
+#include "../sounds/Sd8.h"
+#include "../sounds/SdNoise.h"
+#include "../sounds/Tom.h"
+
+
+SaiHandle::Config::SampleRate audioSampleRate = SaiHandle::Config::SampleRate::SAI_32KHZ;
 
 IDrum *drums[16];
+IDrum *sources[2];
 u8 drumCount = 16;
+u8 sourceCount = 2;
 DrumWrapper drumWrappers[16];
 
+// sounds
 Bd8 bd;
 DrumWrapper bdWrapper;
 SdNoise rs;
@@ -28,12 +50,15 @@ HhSource68 source68;
 ClickSource clickSource;
 // MultiTomSource multiTomSource;
 
+
 void InitKit(float samplerate) {
 
     // Init any sound sources
     source68.Init("", samplerate, HhSource68::MORPH_808_VALUE);
     clickSource.Init("", samplerate, 1500, 191, 116);
     // multiTomSource.Init("", samplerate, 500, &clickSource);
+    sources[0] = &source68;
+    sources[1] = &clickSource;
 
     // Init all drum sounds
     bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);

--- a/HachiKit/kits/kit-abcd.h
+++ b/HachiKit/kits/kit-abcd.h
@@ -1,0 +1,85 @@
+
+IDrum *drums[16];
+u8 drumCount = 16;
+DrumWrapper drumWrappers[16];
+
+Bd8 bd;
+DrumWrapper bdWrapper;
+SdNoise rs;
+Sd8 sd;
+Clap cp;
+DigiClap sd2;
+Tom lt, mt, ht;
+// MultiTom lt, mt, ht;
+Ch ch;
+Oh oh;
+SdNoise ma;
+Cy cy;
+Cow8 cb;
+FmDrum fm1, fm2;
+Clave8 cl;
+
+// Shared sound sources
+HhSource68 source68;
+ClickSource clickSource;
+// MultiTomSource multiTomSource;
+
+void InitKit(float samplerate) {
+
+    // Init any sound sources
+    source68.Init("", samplerate, HhSource68::MORPH_808_VALUE);
+    clickSource.Init("", samplerate, 1500, 191, 116);
+    // multiTomSource.Init("", samplerate, 500, &clickSource);
+
+    // Init all drum sounds
+    bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
+    rs.Init("RS", samplerate);
+    sd.Init("SD", samplerate);
+    cp.Init("CP", samplerate, 0.012, 0.8);
+    sd2.Init("S2", samplerate, 0.012, 0.8, 3000, 0);
+
+    lt.Init("LT", samplerate, 80, &clickSource);
+    mt.Init("MT", samplerate, 91, &clickSource);
+    ht.Init("HT", samplerate, 106, &clickSource);
+    // lt.Init("LT", samplerate, 80, 0.8, &multiTomSource, 0);
+    // mt.Init("MT", samplerate, 91, 0.8, &multiTomSource, 1);
+    // ht.Init("HT", samplerate, 106, 0.8, &multiTomSource, 2);
+
+
+    ch.Init("CH", samplerate, 0.001, 0.5, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
+    oh.Init("OH", samplerate, 0.001, 0.13, 0.001, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
+    ma.Init("MA", samplerate);
+    cy.Init("CY", samplerate, 0.001, 3.5, &source68, 1700, 2400);
+    cb.Init("CB", samplerate, 0.005, 0.5, &source68, 1700, 2400);
+    fm1.Init("LC", samplerate, 98, 3.3, 2.2, 0.001, 0.101, -50);
+    fm2.Init("HC", samplerate, 131, 3.3, 2.2, 0.001, 0.101, -50);
+    cl.Init("CL", samplerate, 2000, 0.375);
+
+    // Assign sounds to kit
+    drums[0] = &bd;
+    drums[1] = &rs;
+    drums[2] = &sd;
+    drums[3] = &cp;
+    drums[4] = &sd2;
+    drums[5] = &lt;
+    drums[6] = &ch;
+    drums[7] = &mt;
+    drums[8] = &ma;
+    drums[9] = &ht;
+    drums[10] = &oh;
+    drums[11] = &fm1;
+    drums[12] = &fm2;
+    drums[13] = &cy;
+    drums[14] = &cl;
+    drums[15] = &cb;
+
+    for (u8 i = 0; i < drumCount; i++) {
+        drumWrappers[i].Init(drums[i]);
+        drums[i] = &drumWrappers[i];
+    }
+    
+    // buffers don't work well with claps; cymbal is just too long
+    drumWrappers[3].setBufferEnabled(false);
+    drumWrappers[4].setBufferEnabled(false);
+    drumWrappers[13].setBufferEnabled(false);
+}

--- a/HachiKit/kits/kit-abcd.h
+++ b/HachiKit/kits/kit-abcd.h
@@ -1,3 +1,7 @@
+// all kit .h files should include this so only one can get loaded
+#ifndef DRUMKIT_H
+#define DRUMKIT_H
+
 
 IDrum *drums[16];
 u8 drumCount = 16;
@@ -79,7 +83,9 @@ void InitKit(float samplerate) {
     }
     
     // buffers don't work well with claps; cymbal is just too long
-    drumWrappers[3].setBufferEnabled(false);
-    drumWrappers[4].setBufferEnabled(false);
-    drumWrappers[13].setBufferEnabled(false);
+    // drumWrappers[3].setBufferEnabled(false);
+    // drumWrappers[4].setBufferEnabled(false);
+    // drumWrappers[13].setBufferEnabled(false);
 }
+
+#endif

--- a/HachiKit/kits/testing.h
+++ b/HachiKit/kits/testing.h
@@ -1,3 +1,6 @@
+// all kit .h files should include this so only one can get loaded
+#ifndef DRUMKIT_H
+#define DRUMKIT_H
 
 IDrum *drums[1];
 u8 drumCount = 1;
@@ -9,7 +12,7 @@ Bd8 bd;
 void InitKit(float samplerate) {
 
     // Init all drum sounds
-    bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
+    bd.Init("BD", samplerate, 64, 0.1, 4, 0.1, 0.15, 125);
 
     // Assign sounds to kit
     drums[0] = &bd;
@@ -19,6 +22,8 @@ void InitKit(float samplerate) {
         drums[i] = &drumWrappers[i];
     }
 
-    // drumWrappers[0].setBufferEnabled(false);
+    drumWrappers[0].setBufferEnabled(false);
 
 }
+
+#endif

--- a/HachiKit/kits/testing.h
+++ b/HachiKit/kits/testing.h
@@ -1,0 +1,24 @@
+
+IDrum *drums[1];
+u8 drumCount = 1;
+DrumWrapper drumWrappers[1];
+
+Bd8 bd;
+
+
+void InitKit(float samplerate) {
+
+    // Init all drum sounds
+    bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
+
+    // Assign sounds to kit
+    drums[0] = &bd;
+
+    for (u8 i = 0; i < drumCount; i++) {
+        drumWrappers[i].Init(drums[i]);
+        drums[i] = &drumWrappers[i];
+    }
+
+    // drumWrappers[0].setBufferEnabled(false);
+
+}

--- a/HachiKit/kits/testing.h
+++ b/HachiKit/kits/testing.h
@@ -2,27 +2,45 @@
 #ifndef DRUMKIT_H
 #define DRUMKIT_H
 
-IDrum *drums[1];
-u8 drumCount = 1;
+#include "../sounds/Bd8.h"
+#include "../sounds/Ch.h"
+#include "../sounds/HhSource68.h"
+
+
+SaiHandle::Config::SampleRate audioSampleRate = SaiHandle::Config::SampleRate::SAI_32KHZ;
+
+IDrum *drums[2];
+IDrum *sources[1];
+u8 drumCount = 2;
+u8 sourceCount = 1;
 DrumWrapper drumWrappers[1];
 
+// sounds
 Bd8 bd;
+Ch ch;
+
+// Shared sound sources
+HhSource68 source68;
 
 
 void InitKit(float samplerate) {
 
+    // Init any sound sources
+    source68.Init("", samplerate, HhSource68::MORPH_808_VALUE);
+    sources[0] = &source68;
+
     // Init all drum sounds
-    bd.Init("BD", samplerate, 64, 0.1, 4, 0.1, 0.15, 125);
+    bd.Init("BD", samplerate, 64, 0.001, 4, 0.001, 0.15, 125);
+    ch.Init("CH", samplerate, 0.001, 0.5, &source68, HhSource68::MORPH_808_VALUE, 6000, 16000);
 
     // Assign sounds to kit
     drums[0] = &bd;
+    drums[1] = &ch;
 
     for (u8 i = 0; i < drumCount; i++) {
         drumWrappers[i].Init(drums[i]);
         drums[i] = &drumWrappers[i];
     }
-
-    drumWrappers[0].setBufferEnabled(false);
 
 }
 

--- a/HachiKit/sounds/Bd8.cpp
+++ b/HachiKit/sounds/Bd8.cpp
@@ -35,9 +35,6 @@ void Bd8::Init(std::string slot, float sample_rate, float frequency, float ampAt
 }
 
 float Bd8::Process() {
-    if (!active && cycleCount > 100) return 0.0f; 
-
-    cycleCount++;
     float psig = pitchEnv.Process();
     osc.SetFreq(parameters[PARAM_FREQUENCY].GetScaledValue() + parameters[PARAM_MOD_AMT].GetScaledValue() * psig);
     active = ampEnv.IsRunning();
@@ -48,7 +45,6 @@ void Bd8::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
         osc.Reset();
-        cycleCount = 0;
         active = true;
         ampEnv.Trigger();
         pitchEnv.Trigger();

--- a/HachiKit/sounds/Bd8.cpp
+++ b/HachiKit/sounds/Bd8.cpp
@@ -35,9 +35,12 @@ void Bd8::Init(std::string slot, float sample_rate, float frequency, float ampAt
 }
 
 float Bd8::Process() {
+    if (!active && cycleCount > 100) return 0.0f; 
+
+    cycleCount++;
     float psig = pitchEnv.Process();
     osc.SetFreq(parameters[PARAM_FREQUENCY].GetScaledValue() + parameters[PARAM_MOD_AMT].GetScaledValue() * psig);
-    // osc.SetFreq(parameters[PARAM_FREQUENCY].GetScaledValue());
+    active = ampEnv.IsRunning();
     return 6 * velocity * osc.Process() * ampEnv.Process();
 }
 
@@ -45,6 +48,8 @@ void Bd8::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
         osc.Reset();
+        cycleCount = 0;
+        active = true;
         ampEnv.Trigger();
         pitchEnv.Trigger();
     }

--- a/HachiKit/sounds/Bd8.h
+++ b/HachiKit/sounds/Bd8.h
@@ -47,7 +47,6 @@ class Bd8: public IDrum {
         std::string paramNames[PARAM_COUNT] = { "Freq", "Mod", "aDcy", "pDcy", "aAtk", "pAtk", "aCrv" };
         std::string slot;
         bool active = false;
-        u32 cycleCount = 0;
         Param parameters[PARAM_COUNT];
         Oscillator osc;
         AdEnv ampEnv;

--- a/HachiKit/sounds/Bd8.h
+++ b/HachiKit/sounds/Bd8.h
@@ -31,6 +31,7 @@ class Bd8: public IDrum {
         void Init(std::string slot, float sample_rate, float frequency, float ampAttack, float ampDecay, float pitchAttack, float pitchDecay, float modAmount);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         std::string GetParamString(uint8_t param);
@@ -45,6 +46,8 @@ class Bd8: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Freq", "Mod", "aDcy", "pDcy", "aAtk", "pAtk", "aCrv" };
         std::string slot;
+        bool active = false;
+        u32 cycleCount = 0;
         Param parameters[PARAM_COUNT];
         Oscillator osc;
         AdEnv ampEnv;

--- a/HachiKit/sounds/Blank.cpp
+++ b/HachiKit/sounds/Blank.cpp
@@ -19,8 +19,6 @@ void Blank::Init(std::string slot, float sample_rate, float frequency, float att
 }
 
 float Blank::Process() {
-    if (!active) return 0.0f; 
-
     // set active based on whether main amp env is running
     return 0.0f;
 }

--- a/HachiKit/sounds/Blank.cpp
+++ b/HachiKit/sounds/Blank.cpp
@@ -19,12 +19,16 @@ void Blank::Init(std::string slot, float sample_rate, float frequency, float att
 }
 
 float Blank::Process() {
+    if (!active) return 0.0f; 
+
+    // set active based on whether main amp env is running
     return 0.0f;
 }
 
 void Blank::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
+        active = true;
         // trigger envelopes
     }
 }

--- a/HachiKit/sounds/Blank.h
+++ b/HachiKit/sounds/Blank.h
@@ -25,6 +25,7 @@ class Blank: public IDrum {
         void Init(std::string slot, float sample_rate, float frequency, float attack, float decay);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         std::string GetParamString(uint8_t param);
@@ -39,6 +40,7 @@ class Blank: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Freq", "Atk", "Dcy" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         // audio objects

--- a/HachiKit/sounds/Blank.h
+++ b/HachiKit/sounds/Blank.h
@@ -20,6 +20,7 @@ class Blank: public IDrum {
         static const uint8_t PARAM_FREQUENCY = 0;
         static const uint8_t PARAM_ATTACK = 1;
         static const uint8_t PARAM_DECAY = 2;
+        u8 ParamCount() { return PARAM_COUNT; }
 
         void Init(std::string slot, float sample_rate);
         void Init(std::string slot, float sample_rate, float frequency, float attack, float decay);

--- a/HachiKit/sounds/Ch.cpp
+++ b/HachiKit/sounds/Ch.cpp
@@ -30,10 +30,13 @@ void Ch::Init(std::string slot, float sample_rate, float attack, float decay, Hh
 }
 
 float Ch::Process() {
+    if (!active) return 0.0f; 
+
     if (source == NULL) {
         return 0.0f;
     }
 
+    active = env.IsRunning();
     float sig = source->Signal() * env.Process();
     return velocity * sig;
 }
@@ -41,6 +44,7 @@ float Ch::Process() {
 void Ch::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
+        active = true;
         env.Trigger();
     }
 }

--- a/HachiKit/sounds/Ch.cpp
+++ b/HachiKit/sounds/Ch.cpp
@@ -30,8 +30,6 @@ void Ch::Init(std::string slot, float sample_rate, float attack, float decay, Hh
 }
 
 float Ch::Process() {
-    if (!active) return 0.0f; 
-
     if (source == NULL) {
         return 0.0f;
     }

--- a/HachiKit/sounds/Ch.h
+++ b/HachiKit/sounds/Ch.h
@@ -31,6 +31,7 @@ class Ch: public IDrum {
         void Init(std::string slot, float sample_rate, float attack, float decay, HhSource68 *source, float morph, float hpf, float lpf);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         float UpdateParam(uint8_t param, float value);
@@ -45,6 +46,7 @@ class Ch: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Atk", "Dcy", "Mrph", "Hpf", "Lpf" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         // ISource *source = NULL;

--- a/HachiKit/sounds/Clap.cpp
+++ b/HachiKit/sounds/Clap.cpp
@@ -24,6 +24,8 @@ void Clap::Init(std::string slot, float sample_rate, float spread, float decay) 
 }
 
 float Clap::Process() {
+    if (!active) return 0.0f; 
+
     if (!env.IsRunning()) {
         repeat++;
         if (repeat == REPEATS) {
@@ -33,6 +35,7 @@ float Clap::Process() {
             env.Trigger();
         }
     }
+    active = env.IsRunning(); 
     return velocity * noise.Process() * env.Process();
 }
 
@@ -40,6 +43,7 @@ void Clap::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
         repeat = 0;
+        active = true;
         env.SetTime(ADENV_SEG_DECAY, GetParam(PARAM_SPREAD));
         env.Trigger();
     }

--- a/HachiKit/sounds/Clap.cpp
+++ b/HachiKit/sounds/Clap.cpp
@@ -28,13 +28,17 @@ float Clap::Process() {
         repeat++;
         if (repeat == REPEATS) {
             env.SetTime(ADENV_SEG_DECAY, GetParam(PARAM_DECAY));
-        }
+        } 
         if (repeat <= REPEATS) {
             env.Trigger();
         }
     }
-    active = env.IsRunning(); 
-    return velocity * noise.Process() * env.Process();
+    if (repeat <= REPEATS) {
+        active = true;
+    } else {
+        active = env.IsRunning(); 
+    }
+    return 3 * velocity * noise.Process() * env.Process();
 }
 
 void Clap::Trigger(float velocity) {

--- a/HachiKit/sounds/Clap.cpp
+++ b/HachiKit/sounds/Clap.cpp
@@ -24,8 +24,6 @@ void Clap::Init(std::string slot, float sample_rate, float spread, float decay) 
 }
 
 float Clap::Process() {
-    if (!active) return 0.0f; 
-
     if (!env.IsRunning()) {
         repeat++;
         if (repeat == REPEATS) {

--- a/HachiKit/sounds/Clap.h
+++ b/HachiKit/sounds/Clap.h
@@ -27,6 +27,7 @@ class Clap: public IDrum {
         void Init(std::string slot, float sample_rate, float spread, float decay);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         std::string GetParamString(uint8_t param);
@@ -41,6 +42,7 @@ class Clap: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Sprd", "Dcy" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         float repeat;

--- a/HachiKit/sounds/Clave8.cpp
+++ b/HachiKit/sounds/Clave8.cpp
@@ -32,8 +32,6 @@ void Clave8::Init(std::string slot, float sample_rate, float frequency, float am
 }
 
 float Clave8::Process() {
-    if (!active) return 0.0f; 
-
     active = ampEnv.IsRunning();
     bpf.Process(osc.Process());
     return velocity * bpf.Band() * ampEnv.Process() * 3;

--- a/HachiKit/sounds/Clave8.cpp
+++ b/HachiKit/sounds/Clave8.cpp
@@ -32,6 +32,9 @@ void Clave8::Init(std::string slot, float sample_rate, float frequency, float am
 }
 
 float Clave8::Process() {
+    if (!active) return 0.0f; 
+
+    active = ampEnv.IsRunning();
     bpf.Process(osc.Process());
     return velocity * bpf.Band() * ampEnv.Process() * 3;
 }
@@ -40,6 +43,7 @@ void Clave8::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
         osc.Reset();
+        active = true;
         ampEnv.Trigger();
     }
 }

--- a/HachiKit/sounds/Clave8.h
+++ b/HachiKit/sounds/Clave8.h
@@ -26,6 +26,7 @@ class Clave8: public IDrum {
         void Init(std::string slot, float sample_rate, float frequency, float ampDecay);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         std::string GetParamString(uint8_t param);
@@ -40,6 +41,7 @@ class Clave8: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Freq", "Dcy" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         Oscillator osc;
         AdEnv ampEnv;

--- a/HachiKit/sounds/ClickSource.cpp
+++ b/HachiKit/sounds/ClickSource.cpp
@@ -35,8 +35,6 @@ void ClickSource::Init(std::string slot, float sample_rate, float hpfFreq, float
 }
 
 float ClickSource::Process() {
-    if (!active) return 0.0f; 
-
     // noise goes through a hpf, then through an lpf modulated by the lpf env.
     // lpf env also controls amp of noise
     float lpfEnvSignal = lpfEnv.Process();

--- a/HachiKit/sounds/ClickSource.cpp
+++ b/HachiKit/sounds/ClickSource.cpp
@@ -35,6 +35,8 @@ void ClickSource::Init(std::string slot, float sample_rate, float hpfFreq, float
 }
 
 float ClickSource::Process() {
+    if (!active) return 0.0f; 
+
     // noise goes through a hpf, then through an lpf modulated by the lpf env.
     // lpf env also controls amp of noise
     float lpfEnvSignal = lpfEnv.Process();
@@ -42,12 +44,14 @@ float ClickSource::Process() {
     hpf.Process(noise.Process());
     lpf.Process(hpf.High());
     signal = lpf.Low() * lpfEnvSignal;
+    active = lpfEnv.IsRunning(); // lpfEnv is also the amp env for the click
     return signal;
 }
 
 void ClickSource::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
+        active = true;
         lpfEnv.Trigger();
     }
 }

--- a/HachiKit/sounds/ClickSource.h
+++ b/HachiKit/sounds/ClickSource.h
@@ -27,6 +27,7 @@ class ClickSource: public IDrum {
         void Init(std::string slot, float sample_rate, float hpfFreq, float lpfFreq, float mod);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
         float Signal() { return signal; }
 
         float GetParam(uint8_t param);
@@ -42,6 +43,7 @@ class ClickSource: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Hpf", "Lpf", "fMod" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         float signal;

--- a/HachiKit/sounds/Cow8.cpp
+++ b/HachiKit/sounds/Cow8.cpp
@@ -43,6 +43,8 @@ void Cow8::Init(std::string slot, float sample_rate, float attack, float decay, 
 }
 
 float Cow8::Process() {
+    if (!active) return 0.0f; 
+
     if (source == NULL) {
         return 0.0f;
     }
@@ -50,12 +52,14 @@ float Cow8::Process() {
     float sig = source->Cowbell(false) * env.Process();
     hpf.Process(sig);
     lpf.Process(hpf.High());
+    active = env.IsRunning();
     return velocity * lpf.Low();;
 }
 
 void Cow8::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
+        active = true;
         env.Trigger();
     }
 }

--- a/HachiKit/sounds/Cow8.cpp
+++ b/HachiKit/sounds/Cow8.cpp
@@ -43,8 +43,6 @@ void Cow8::Init(std::string slot, float sample_rate, float attack, float decay, 
 }
 
 float Cow8::Process() {
-    if (!active) return 0.0f; 
-
     if (source == NULL) {
         return 0.0f;
     }

--- a/HachiKit/sounds/Cow8.h
+++ b/HachiKit/sounds/Cow8.h
@@ -35,6 +35,7 @@ class Cow8: public IDrum {
         void Init(std::string slot, float sample_rate, float attack, float decay, HhSource68 *source, float hpfCutoff, float lpfCutoff);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         float UpdateParam(uint8_t param, float value);
@@ -49,6 +50,7 @@ class Cow8: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Atk", "Dcy", "Hpf", "Lpf" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         // ISource *source = NULL;

--- a/HachiKit/sounds/Cy.cpp
+++ b/HachiKit/sounds/Cy.cpp
@@ -42,8 +42,6 @@ void Cy::Init(std::string slot, float sample_rate, float attack, float decay, Hh
 }
 
 float Cy::Process() {
-    if (!active) return 0.0f; 
-
     if (source == NULL) {
         return 0.0f;
     }

--- a/HachiKit/sounds/Cy.cpp
+++ b/HachiKit/sounds/Cy.cpp
@@ -42,6 +42,8 @@ void Cy::Init(std::string slot, float sample_rate, float attack, float decay, Hh
 }
 
 float Cy::Process() {
+    if (!active) return 0.0f; 
+
     if (source == NULL) {
         return 0.0f;
     }
@@ -60,12 +62,14 @@ float Cy::Process() {
     // }
     // bufferIndex++;
 
+    active = env.IsRunning();
     return velocity * sig;
 }
 
 void Cy::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
+        active = true;
         env.Trigger();
         bufferIndex = 0;
     }

--- a/HachiKit/sounds/Cy.cpp
+++ b/HachiKit/sounds/Cy.cpp
@@ -69,7 +69,7 @@ void Cy::Trigger(float velocity) {
     if (this->velocity > 0) {
         active = true;
         env.Trigger();
-        bufferIndex = 0;
+        // bufferIndex = 0;
     }
 }
 

--- a/HachiKit/sounds/Cy.h
+++ b/HachiKit/sounds/Cy.h
@@ -30,7 +30,7 @@ class Cy: public IDrum {
         static const float HPF_MIN;
         static const float LPF_MAX;
         static const float LPF_MIN;
-        static const u16 BUFFER_SIZE = 100;
+        // static const u16 BUFFER_SIZE = 100;
 
         void Init(std::string slot, float sample_rate);
         void Init(std::string slot, float sample_rate, float attack, float decay, HhSource68 *source, float hpfCutoff, float lpfCutoff);
@@ -59,9 +59,9 @@ class Cy: public IDrum {
         AdEnv env;
         Svf hpf, lpf;
 
-        float buffer[BUFFER_SIZE];
-        bool bufferValid = false;
-        u16 bufferIndex = 0;
+        // float buffer[BUFFER_SIZE];
+        // bool bufferValid = false;
+        // u16 bufferIndex = 0;
 
 };
 

--- a/HachiKit/sounds/Cy.h
+++ b/HachiKit/sounds/Cy.h
@@ -36,6 +36,7 @@ class Cy: public IDrum {
         void Init(std::string slot, float sample_rate, float attack, float decay, HhSource68 *source, float hpfCutoff, float lpfCutoff);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         float UpdateParam(uint8_t param, float value);
@@ -50,6 +51,7 @@ class Cy: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Atk", "Dcy", "Hpf", "Lpf" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         // ISource *source = NULL;

--- a/HachiKit/sounds/DigiClap.cpp
+++ b/HachiKit/sounds/DigiClap.cpp
@@ -26,8 +26,6 @@ void DigiClap::Init(std::string slot, float sample_rate, float spread, float dec
 }
 
 float DigiClap::Process() {
-    if (!active) return 0.0f; 
-
     if (!env.IsRunning()) {
         repeat++;
         if (repeat == REPEATS) {

--- a/HachiKit/sounds/DigiClap.cpp
+++ b/HachiKit/sounds/DigiClap.cpp
@@ -26,6 +26,8 @@ void DigiClap::Init(std::string slot, float sample_rate, float spread, float dec
 }
 
 float DigiClap::Process() {
+    if (!active) return 0.0f; 
+
     if (!env.IsRunning()) {
         repeat++;
         if (repeat == REPEATS) {
@@ -35,6 +37,7 @@ float DigiClap::Process() {
             env.Trigger();
         }
     }
+    active = env.IsRunning();
     return velocity * clockedNoise.Process() * env.Process();
 }
 
@@ -43,6 +46,7 @@ void DigiClap::Trigger(float velocity) {
     if (this->velocity > 0) {
         repeat = 0;
         env.SetTime(ADENV_SEG_DECAY, GetParam(PARAM_SPREAD));
+        active = true;
         env.Trigger();
     }
 }

--- a/HachiKit/sounds/DigiClap.h
+++ b/HachiKit/sounds/DigiClap.h
@@ -15,17 +15,18 @@ class DigiClap: public IDrum {
 
     public:
         // Number of settable parameters for this model.
-        static const uint8_t PARAM_COUNT = 3;
+        static const uint8_t PARAM_COUNT = 4;
         // This is the order params will appear in the UI.
         static const uint8_t PARAM_SPREAD = 0;
         static const uint8_t PARAM_DECAY = 1;
         static const uint8_t PARAM_FREQUENCY = 2;
+        static const uint8_t PARAM_MOD = 3;
         u8 ParamCount() { return PARAM_COUNT; }
 
         static const uint8_t REPEATS = 3;
 
         void Init(std::string slot, float sample_rate);
-        void Init(std::string slot, float sample_rate, float spread, float decay, float frequency);
+        void Init(std::string slot, float sample_rate, float spread, float decay, float frequency, float mod);
         float Process();
         void Trigger(float velocity);
         bool IsActive() { return active; }
@@ -41,7 +42,7 @@ class DigiClap: public IDrum {
         std::string GetParamName(uint8_t param) { return param < PARAM_COUNT ? paramNames[param] : ""; }
 
     private:
-        std::string paramNames[PARAM_COUNT] = { "Sprd", "Dcy", "Freq" };
+        std::string paramNames[PARAM_COUNT] = { "Sprd", "Dcy", "Freq", "Mod" };
         std::string slot;
         bool active = false;
         Param parameters[PARAM_COUNT];

--- a/HachiKit/sounds/DigiClap.h
+++ b/HachiKit/sounds/DigiClap.h
@@ -28,6 +28,7 @@ class DigiClap: public IDrum {
         void Init(std::string slot, float sample_rate, float spread, float decay, float frequency);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         std::string GetParamString(uint8_t param);
@@ -42,6 +43,7 @@ class DigiClap: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Sprd", "Dcy", "Freq" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         float repeat;

--- a/HachiKit/sounds/FmDrum.cpp
+++ b/HachiKit/sounds/FmDrum.cpp
@@ -27,6 +27,9 @@ void FmDrum::Init(std::string slot, float sample_rate, float frequency, float ra
 }
 
 float FmDrum::Process() {
+    if (!active) return 0.0f; 
+
+    active = ampEnv.IsRunning();
     return velocity * fm.Process() * ampEnv.Process();
 }
 
@@ -34,6 +37,7 @@ void FmDrum::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
         fm.Reset();
+        active = true;
         ampEnv.Trigger();
     }
 }

--- a/HachiKit/sounds/FmDrum.cpp
+++ b/HachiKit/sounds/FmDrum.cpp
@@ -27,8 +27,6 @@ void FmDrum::Init(std::string slot, float sample_rate, float frequency, float ra
 }
 
 float FmDrum::Process() {
-    if (!active) return 0.0f; 
-
     active = ampEnv.IsRunning();
     return velocity * fm.Process() * ampEnv.Process();
 }

--- a/HachiKit/sounds/FmDrum.h
+++ b/HachiKit/sounds/FmDrum.h
@@ -29,6 +29,7 @@ class FmDrum: public IDrum {
         void Init(std::string slot, float sample_rate, float frequency, float ratio, float modAmount, float attack, float decay, float curve);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         float UpdateParam(uint8_t param, float value);
@@ -43,6 +44,7 @@ class FmDrum: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Freq", "Ratio", "Mod", "Dcy", "Atk", "Curve" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         Fm2 fm;

--- a/HachiKit/sounds/HhSource68.cpp
+++ b/HachiKit/sounds/HhSource68.cpp
@@ -51,6 +51,8 @@ void HhSource68::Init(std::string slot, float sample_rate, float morph) {
 }
 
 float HhSource68::Process() {
+    // HhSource68 is always active
+
     float sig = cowSignal = lowCowSignal = 0.0f;
     for (int osc = 0; osc < OSC_COUNT; osc++) {
         float oscSignal = oscs[osc]->Process();

--- a/HachiKit/sounds/HhSource68.h
+++ b/HachiKit/sounds/HhSource68.h
@@ -46,6 +46,7 @@ class HhSource68: public IDrum {
 
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return true; }
         float Signal();
         float Cowbell(bool isLow);
 
@@ -66,6 +67,7 @@ class HhSource68: public IDrum {
 
         std::string paramNames[PARAM_COUNT] = { "Mrph", "HPF", "LPF" };
         std::string slot;
+        // bool active = false;  // HhSource68 is always active
         Param parameters[PARAM_COUNT];
 
         float signal = 0.0f;

--- a/HachiKit/sounds/MultiTom.cpp
+++ b/HachiKit/sounds/MultiTom.cpp
@@ -18,6 +18,9 @@ void MultiTom::Init(std::string slot, float sample_rate, float frequency, float 
 }
 
 float MultiTom::Process() {
+    if (!active) return 0.0f; 
+
+    active = multiTomSource->IsActive();
     return multiTomSource->Signal();
 }
 

--- a/HachiKit/sounds/MultiTom.cpp
+++ b/HachiKit/sounds/MultiTom.cpp
@@ -18,8 +18,6 @@ void MultiTom::Init(std::string slot, float sample_rate, float frequency, float 
 }
 
 float MultiTom::Process() {
-    if (!active) return 0.0f; 
-
     active = multiTomSource->IsActive();
     return multiTomSource->Signal();
 }

--- a/HachiKit/sounds/MultiTom.h
+++ b/HachiKit/sounds/MultiTom.h
@@ -26,6 +26,7 @@ class MultiTom: public IDrum {
         void Init(std::string slot, float sample_rate, float frequency, float ampDecay, MultiTomSource *multiTomSource, u8 index);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         std::string GetParamString(uint8_t param);
@@ -40,6 +41,7 @@ class MultiTom: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Freq", "Dcy" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         u8 index;

--- a/HachiKit/sounds/MultiTomSource.cpp
+++ b/HachiKit/sounds/MultiTomSource.cpp
@@ -36,7 +36,6 @@ void MultiTomSource::Init(std::string slot, float sample_rate, float decay, Clic
 }
 
 float MultiTomSource::Process() {
-    if (!active) return 0.0f; 
 
     float clickSignal = clickSource == NULL ? 0.0f : clickSource->Signal();
     

--- a/HachiKit/sounds/MultiTomSource.cpp
+++ b/HachiKit/sounds/MultiTomSource.cpp
@@ -36,6 +36,7 @@ void MultiTomSource::Init(std::string slot, float sample_rate, float decay, Clic
 }
 
 float MultiTomSource::Process() {
+    if (!active) return 0.0f; 
 
     float clickSignal = clickSource == NULL ? 0.0f : clickSource->Signal();
     
@@ -45,6 +46,7 @@ float MultiTomSource::Process() {
     osc.SetFreq(currentBaseFrequency + 60 * pitchEnvSignal);
     float oscSignal = osc.Process() * ampEnvSignal;
 
+    active = ampEnv.IsRunning();
     signal = (clickSignal + oscSignal) * velocity * currentGain; 
     return signal;
 }
@@ -53,6 +55,7 @@ void MultiTomSource::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
         currentGain = 1.0f;
+        active = true;
         // clickSource->Trigger(velocity);
         ampEnv.Trigger();
         // pitchEnv.Trigger();

--- a/HachiKit/sounds/MultiTomSource.h
+++ b/HachiKit/sounds/MultiTomSource.h
@@ -28,6 +28,7 @@ class MultiTomSource: public IDrum {
         float Signal() { return signal; }
         void Trigger(float velocity);
         void Trigger(float velocity, u8 index, float frequency);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         float UpdateParam(uint8_t param, float value);
@@ -42,6 +43,7 @@ class MultiTomSource: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Freq" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
 
         float velocity;

--- a/HachiKit/sounds/Oh.cpp
+++ b/HachiKit/sounds/Oh.cpp
@@ -28,8 +28,6 @@ void Oh::Init(std::string slot, float sample_rate, float attack, float hold, flo
 }
 
 float Oh::Process() {
-    if (!active) return 0.0f; 
-
     if (source == NULL) {
         return 0.0f;
     }

--- a/HachiKit/sounds/Oh.cpp
+++ b/HachiKit/sounds/Oh.cpp
@@ -28,17 +28,21 @@ void Oh::Init(std::string slot, float sample_rate, float attack, float hold, flo
 }
 
 float Oh::Process() {
+    if (!active) return 0.0f; 
+
     if (source == NULL) {
         return 0.0f;
     }
 
     float sig = source->Signal() * env.Process();
+    active = env.IsRunning();
     return velocity * sig;
 }
 
 void Oh::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
+        active = true;
         env.Trigger();
     }
 }

--- a/HachiKit/sounds/Oh.h
+++ b/HachiKit/sounds/Oh.h
@@ -33,6 +33,7 @@ class Oh: public IDrum {
         void Init(std::string slot, float sample_rate, float attack, float hold, float decay, HhSource68 *source, float morph, float hpf, float lpf);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         float UpdateParam(uint8_t param, float value);
@@ -47,6 +48,7 @@ class Oh: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Atk", "Hold", "Dcy", "Lpf", "Mrph", "Hpf" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         HhSource68 *source = NULL;

--- a/HachiKit/sounds/Sd8.cpp
+++ b/HachiKit/sounds/Sd8.cpp
@@ -42,8 +42,6 @@ void Sd8::Init(std::string slot, float sample_rate, float oscFrequency, float os
 }
 
 float Sd8::Process() {
-    if (!active) return 0.0f; 
-
     float sig = (1 - parameters[PARAM_MIX].GetScaledValue()) * osc.Process() * oscEnv.Process();
     sig += parameters[PARAM_MIX].GetScaledValue() * noise.Process() * noiseEnv.Process();
     active = oscEnv.IsRunning() || noiseEnv.IsRunning();

--- a/HachiKit/sounds/Sd8.cpp
+++ b/HachiKit/sounds/Sd8.cpp
@@ -42,8 +42,11 @@ void Sd8::Init(std::string slot, float sample_rate, float oscFrequency, float os
 }
 
 float Sd8::Process() {
+    if (!active) return 0.0f; 
+
     float sig = (1 - parameters[PARAM_MIX].GetScaledValue()) * osc.Process() * oscEnv.Process();
     sig += parameters[PARAM_MIX].GetScaledValue() * noise.Process() * noiseEnv.Process();
+    active = oscEnv.IsRunning() || noiseEnv.IsRunning();
     return velocity * sig * 6; 
 }
 
@@ -51,6 +54,7 @@ void Sd8::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
         osc.Reset();
+        active = true;
         oscEnv.Trigger();
         noiseEnv.Trigger();
     }

--- a/HachiKit/sounds/Sd8.h
+++ b/HachiKit/sounds/Sd8.h
@@ -29,6 +29,7 @@ class Sd8: public IDrum {
         void Init(std::string slot, float sample_rate, float oscFrequency, float oscAttack, float oscDecay, float noiseAttack, float noiseDecay, float mix);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         float UpdateParam(uint8_t param, float value);
@@ -43,6 +44,7 @@ class Sd8: public IDrum {
     private:
         static const std::string paramNames[PARAM_COUNT];
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         Oscillator osc;

--- a/HachiKit/sounds/SdNoise.cpp
+++ b/HachiKit/sounds/SdNoise.cpp
@@ -20,12 +20,16 @@ void SdNoise::Init(std::string slot, float sample_rate, float attack, float deca
 }
 
 float SdNoise::Process() {
+    if (!active) return 0.0f; 
+
+    active = ampEnv.IsRunning();
     return velocity * noise.Process() * ampEnv.Process();
 }
 
 void SdNoise::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
+        active = true;
         ampEnv.Trigger();
     }
 }

--- a/HachiKit/sounds/SdNoise.cpp
+++ b/HachiKit/sounds/SdNoise.cpp
@@ -20,8 +20,6 @@ void SdNoise::Init(std::string slot, float sample_rate, float attack, float deca
 }
 
 float SdNoise::Process() {
-    if (!active) return 0.0f; 
-
     active = ampEnv.IsRunning();
     return velocity * noise.Process() * ampEnv.Process();
 }
@@ -88,7 +86,7 @@ void SdNoise::SetParam(uint8_t param, float scaled) {
                 break;
             case PARAM_DECAY: 
                 parameters[param].SetScaledValue(scaled);
-                ampEnv.SetTime(ADENV_SEG_DECAY, scaled);
+               ampEnv.SetTime(ADENV_SEG_DECAY, scaled);
                 break;
             case PARAM_CURVE: 
                 parameters[param].SetScaledValue(scaled);

--- a/HachiKit/sounds/SdNoise.h
+++ b/HachiKit/sounds/SdNoise.h
@@ -26,6 +26,7 @@ class SdNoise: public IDrum {
         void Init(std::string slot, float sample_rate, float attack, float decay, float curve);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         float UpdateParam(uint8_t param, float value);
@@ -40,6 +41,7 @@ class SdNoise: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Atk", "Dcy", "Crv" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         WhiteNoise noise;

--- a/HachiKit/sounds/Tom.cpp
+++ b/HachiKit/sounds/Tom.cpp
@@ -35,7 +35,6 @@ void Tom::Init(std::string slot, float sample_rate, float frequency, ClickSource
 }
 
 float Tom::Process() {
-    if (!active) return 0.0f; 
 
     float clickSignal = clickSource == NULL ? 0.0f :  clickSource->Signal();
     

--- a/HachiKit/sounds/Tom.cpp
+++ b/HachiKit/sounds/Tom.cpp
@@ -35,6 +35,7 @@ void Tom::Init(std::string slot, float sample_rate, float frequency, ClickSource
 }
 
 float Tom::Process() {
+    if (!active) return 0.0f; 
 
     float clickSignal = clickSource == NULL ? 0.0f :  clickSource->Signal();
     
@@ -48,16 +49,18 @@ float Tom::Process() {
     // // // apply velocity scaling more strong to noise than osc
     // // float signal = noiseSignal * velocity + oscSignal * (0.4 + velocity * 0.6);
     // // return signal;
+    active = ampEnv.IsRunning() || clickSource->IsActive();
     return (clickSignal + oscSignal) * velocity; 
 }
 
 void Tom::Trigger(float velocity) {
     this->velocity = Utility::Limit(velocity);
     if (this->velocity > 0) {
+        osc.Reset();
+        active = true;
         clickSource->Trigger(velocity);
         ampEnv.Trigger();
         pitchEnv.Trigger();
-        osc.Reset();
     }
 }
 

--- a/HachiKit/sounds/Tom.h
+++ b/HachiKit/sounds/Tom.h
@@ -32,6 +32,7 @@ class Tom: public IDrum {
         void Init(std::string slot, float sample_rate, float frequency, ClickSource *clickSource);
         float Process();
         void Trigger(float velocity);
+        bool IsActive() { return active; }
 
         float GetParam(uint8_t param);
         float UpdateParam(uint8_t param, float value);
@@ -46,6 +47,7 @@ class Tom: public IDrum {
     private:
         std::string paramNames[PARAM_COUNT] = { "Freq", "aDcy", "pMod", "fMod", "Hpf", "Lpf" };
         std::string slot;
+        bool active = false;
         Param parameters[PARAM_COUNT];
         float velocity;
         Oscillator osc;


### PR DESCRIPTION
Create DrumWrapper, which wraps around an IDrum and calls the Process() method only when the drum is active. 

Also separate kit definition into a .h file for easier swapping.